### PR TITLE
fix Japanese translations of some country names

### DIFF
--- a/config/locales/countries/ja.yml
+++ b/config/locales/countries/ja.yml
@@ -190,7 +190,7 @@ ja:
     Romania: ルーマニア
     Russia: ロシア
     Rwanda: ルワンダ
-    Réunion: 再会
+    Réunion: レユニオン
     Saint Barthélemy: サン・バルテルミー島
     Saint Helena: セントヘレナ
     Saint Kitts and Nevis: セントクリストファー・ネイビス
@@ -230,12 +230,12 @@ ja:
     Tajikistan: タジキスタン
     Tanzania: タンザニア
     Thailand: タイ
-    Togo: 持ち帰り
+    Togo: トーゴ
     Tokelau: トケラウ
     Tonga: トンガ
     Trinidad and Tobago: トリニダード・トバゴ
     Tunisia: チュニジア
-    Turkey: 七面鳥
+    Turkey: トルコ
     Turkmenistan: トルクメニスタン
     Turks and Caicos Islands: タークス・カイコス諸島
     Tuvalu: ツバル
@@ -275,7 +275,7 @@ ja:
     AT: オーストリア
     AU: オーストラリア
     AW: アルバ
-    AX: 土地
+    AX: オーランド諸島
     AZ: アゼルバイジャン
     BA: ボスニア・ヘルツェゴビナ
     BB: バルバドス
@@ -451,7 +451,7 @@ ja:
     PW: パラオ
     PY: パラグアイ
     QA: カタール
-    RE: 再会
+    RE: レユニオン
     RO: ルーマニア
     RS: セルビア
     RU: ロシア
@@ -480,7 +480,7 @@ ja:
     TC: タークス・カイコス諸島
     TD: チャド
     TF: フランス領南方領土
-    TG: 持ち帰り
+    TG: トーゴ
     TH: タイ
     TJ: タジキスタン
     TK: トケラウ
@@ -488,7 +488,7 @@ ja:
     TM: トルクメニスタン
     TN: チュニジア
     TO: トンガ
-    TR: 七面鳥
+    TR: トルコ
     TT: トリニダード・トバゴ
     TV: ツバル
     TW: 台湾


### PR DESCRIPTION
I noticed that the names of several countries had been mistakenly translated into different Japanese words. This PR will fix them.
e.g. [Turkey](https://en.wikipedia.org/wiki/Turkey) -> [七面鳥](https://en.wikipedia.org/wiki/Turkey_(bird))